### PR TITLE
Increase telegram size

### DIFF
--- a/p1mini.h
+++ b/p1mini.h
@@ -74,7 +74,7 @@ private:
     uint32_t obis_code{ 0x00 };
 
     // Store the message as it is being received:
-    constexpr static int message_buffer_size{ 2048 };
+    constexpr static int message_buffer_size{ 4096 };
     char m_message_buffer[message_buffer_size];
     int m_message_buffer_position{ 0 };
     int m_crc_position{ 0 };


### PR DESCRIPTION
In Lithuania, energy provider uses energy meter Sagemcom T211 it sends more data than maximum size of 2048 bytes currently specified. Double the maximum telegram size to 4096.