### PR TITLE
Add state_class and device_class to sensors

### DIFF
--- a/p1mini.yaml
+++ b/p1mini.yaml
@@ -160,6 +160,8 @@ sensor:
     icon: "mdi:transmission-tower-export"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "2.7.0"
@@ -167,6 +169,8 @@ sensor:
     icon: "mdi:transmission-tower-import"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "3.7.0"
@@ -188,6 +192,8 @@ sensor:
     icon: "mdi:transmission-tower-export"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "22.7.0"
@@ -195,6 +201,8 @@ sensor:
     icon: "mdi:transmission-tower-import"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "41.7.0"
@@ -202,6 +210,8 @@ sensor:
     icon: "mdi:transmission-tower-export"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "42.7.0"
@@ -209,6 +219,8 @@ sensor:
     icon: "mdi:transmission-tower-import"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "61.7.0"
@@ -216,6 +228,8 @@ sensor:
     icon: "mdi:transmission-tower-export"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "62.7.0"
@@ -223,6 +237,8 @@ sensor:
     icon: "mdi:transmission-tower-import"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    device_class: "power"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "23.7.0"
@@ -272,6 +288,8 @@ sensor:
     icon: "mdi:lightning-bolt-outline"
     unit_of_measurement: V
     accuracy_decimals: 1
+    device_class: "voltage"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "52.7.0"
@@ -279,6 +297,8 @@ sensor:
     icon: "mdi:lightning-bolt-outline"
     unit_of_measurement: V
     accuracy_decimals: 1
+    device_class: "voltage"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "72.7.0"
@@ -286,6 +306,8 @@ sensor:
     icon: "mdi:lightning-bolt-outline"
     unit_of_measurement: V
     accuracy_decimals: 1
+    device_class: "voltage"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "31.7.0"
@@ -293,6 +315,8 @@ sensor:
     icon: "mdi:lightning-bolt"
     unit_of_measurement: A
     accuracy_decimals: 1
+    device_class: "current"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "51.7.0"
@@ -300,6 +324,8 @@ sensor:
     icon: "mdi:lightning-bolt"
     unit_of_measurement: A
     accuracy_decimals: 1
+    device_class: "current"
+    state_class: "measurement"
   - platform: p1_mini
     p1_mini_id: p1_mini_1
     obis_code: "71.7.0"
@@ -307,6 +333,8 @@ sensor:
     icon: "mdi:lightning-bolt"
     unit_of_measurement: A
     accuracy_decimals: 1
+    device_class: "current"
+    state_class: "measurement"
 #  - platform: p1_mini
 #    p1_mini_id: p1_mini_2
 #    obis_code: "1.8.0"


### PR DESCRIPTION
### Summary

This pull request updates the default ESPhome configuration by adding `state_class` and `device_class` to the sensors.

### Background

The original ESPhome device YAML did not specify `state_class` and `device_class` for the sensors. This became an issue after migrating from [psvanstrom/esphome-p1reader](https://github.com/psvanstrom/esphome-p1reader). Previously, Home Assistant stored the sensor values in long-term statistics, but due to the missing `state_class`, it could no longer do so. This resulted in repair warnings in Home Assistant for each affected sensor.

According to the [Home Assistant sensor documentation](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics), sensors must have a `state_class` to be included in long-term statistics. Adding `state_class` ensures that these values are correctly recorded and maintained over time.

### Changes

- Added `state_class` to allow Home Assistant to store sensor values in long-term statistics.
- Added `device_class` to improve clarity and ensure the correct classification of sensor types.

### Impact

- Resolves Home Assistant repair warnings related to long-term statistics after a migration.
- Ensures that the relevant sensors are automatically stored in long-term statistics for user convenience.
- Improves clarity by explicitly defining `device_class` for each sensor.